### PR TITLE
🔧 (gitignore): add 'dist' directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.afdesign~lock~
 node_modules/
 react
+dist
+


### PR DESCRIPTION
🔧 (gitignore): add 'dist' directory to .gitignore to prevent build artifacts from being tracked